### PR TITLE
This angle was ~120deg off due to mounting change in force torque sensor

### DIFF
--- a/docs/_static/defaults_files/custom_defaults_pulsing_12x4.json
+++ b/docs/_static/defaults_files/custom_defaults_pulsing_12x4.json
@@ -16,7 +16,7 @@
             },
             {
                 "descriptor": "Pulsing Torque Angle",
-                "value": -2.6000001430511475
+                "value": 1.75
             },
             {
                 "descriptor": "Pulsing Voltage Mode",


### PR DESCRIPTION
This has been tested and confirmed. When strain relief was added to the force torque sensor, its mounting angle was changed. This caused the incorrect zero angle to be set when calibrating the motor.