### PR TITLE
fixed bad examples

### DIFF
--- a/docs/clients/iquart_flight_controller_interface.rst
+++ b/docs/clients/iquart_flight_controller_interface.rst
@@ -110,7 +110,7 @@ A minimal working example for the IQUART Flight Controller Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.PulsingModule(com, 0)
     
     telemetry = |variable_name|.get("iquart_flight_controller_interface", "telemetry") 
     print(f"Pulsing voltage mode: {telemetry}")

--- a/docs/clients/iquart_flight_controller_interface.rst
+++ b/docs/clients/iquart_flight_controller_interface.rst
@@ -110,7 +110,7 @@ A minimal working example for the IQUART Flight Controller Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.PulsingModule(com, 0)
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
     
     telemetry = |variable_name|.get("iquart_flight_controller_interface", "telemetry") 
     print(f"Pulsing voltage mode: {telemetry}")

--- a/docs/clients/pulsing_rectangular_input_parser.rst
+++ b/docs/clients/pulsing_rectangular_input_parser.rst
@@ -95,7 +95,7 @@ A minimal working example for the Pulsing Rectangular Input Parser Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
     
     pulsing_voltage_mode = |variable_name|.get("pulsing_rectangular_input_parser", "pulsing_voltage_mode") 
     print(f"Pulsing voltage mode: {pulsing_voltage_mode}")

--- a/docs/clients/voltage_superposition.rst
+++ b/docs/clients/voltage_superposition.rst
@@ -95,7 +95,7 @@ A minimal working example for the Voltage Superposition Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
     
     zero_angle= |variable_name|.get("voltage_superposition", "zero_angle") 
     print(f"Zero angle: {zero_angle}")


### PR DESCRIPTION
there was a broken IFCI example in the docs. I've fixed it. Here's the code it makes: 
![image](https://github.com/iq-motion-control/iq-module-communication-doc/assets/120586722/253b056d-8a4d-4dd9-8805-1e14c1a89e27)
![image](https://github.com/iq-motion-control/iq-module-communication-doc/assets/120586722/df96a714-5723-48ac-a6fb-426d4e33c47e)
![image](https://github.com/iq-motion-control/iq-module-communication-doc/assets/120586722/48160d7b-a21f-4e48-85e6-bed115fd1f1e)
Changing the serial port to COM3 and running prints:
Pulsing voltage mode: (2, 15, 0, 13, 220, 5, 252, 255, 240, 255, 255, 255, 122, 3, 0, 0)