### PR TITLE
fix broken links

### DIFF
--- a/docs/modules/advanced_speed_servo_info.rst
+++ b/docs/modules/advanced_speed_servo_info.rst
@@ -4,9 +4,9 @@ Supported Features
 =================================
         * :ref:`manual_angle_control_mechanisms`
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
-        * :ref:`manual_dronecan`
-        * :ref:`manual_hobby`
+        * :ref:`uart_messaging`
+        * :ref:`dronecan_protocol`
+        * :ref:`hobby_protocol`
         * :ref:`manual_telemetry`
         * :ref:`manual_throttle`
         * :ref:`manual_advanced_arming`
@@ -52,8 +52,8 @@ Supported Features
 =================================
         * :ref:`manual_angle_control_mechanisms`
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
-        * :ref:`manual_hobby`
+        * :ref:`uart_messaging`
+        * :ref:`hobby_protocol`
         * :ref:`manual_timeout`
 
 Supported IQUART Clients

--- a/docs/modules/basic_speed_servo_info.rst
+++ b/docs/modules/basic_speed_servo_info.rst
@@ -3,8 +3,8 @@ Speed Module
 Supported Features
 =================================
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
-        * :ref:`manual_hobby`
+        * :ref:`uart_messaging`
+        * :ref:`hobby_protocol`
         * :ref:`manual_telemetry`
         * :ref:`manual_throttle`
         * :ref:`manual_advanced_arming`
@@ -44,8 +44,8 @@ Supported Features
 =================================
         * :ref:`manual_angle_control_mechanisms`
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
-        * :ref:`manual_hobby`
+        * :ref:`uart_messaging`
+        * :ref:`hobby_protocol`
         * :ref:`manual_timeout`
 
 Supported IQUART Clients

--- a/docs/modules/fortiq_42XX.rst
+++ b/docs/modules/fortiq_42XX.rst
@@ -35,9 +35,9 @@ Supported Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         * :ref:`manual_angle_control_mechanisms`
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
-        * :ref:`manual_canopen`
-        * :ref:`manual_hobby`
+        * :ref:`uart_messaging`
+        * :ref:`canopen_protocol`
+        * :ref:`hobby_protocol`
         * :ref:`manual_timeout`
         * :ref:`manual_adc_interface`
         * :ref:`manual_high_power_pwm_`

--- a/docs/modules/pulsing_module_info.rst
+++ b/docs/modules/pulsing_module_info.rst
@@ -3,7 +3,7 @@ Pulsing Module
 Supported Features
 =============================
         * :ref:`manual_velocity_control_mechanisms`
-        * :ref:`manual_iquart`
+        * :ref:`uart_messaging`
         * :ref:`manual_throttle`
         * :ref:`manual_advanced_arming`
         * :ref:`manual_timeout`

--- a/docs/modules/vertiq_23xx_family.rst
+++ b/docs/modules/vertiq_23xx_family.rst
@@ -96,7 +96,7 @@ Communication - IQUART or Hobby Configuration
 
     23-XX Communication Connections
 
-In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <manual_hobby>` you will have to connect the supplied communication wire to your module. 
+In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <hobby_protocol>` you will have to connect the supplied communication wire to your module. 
 In any scenario, please ensure that the TX line of your module is connected to your controller's RX line, and the RX line 
 of your module is connected to your controller's TX line.
 

--- a/docs/modules/vertiq_40xx_family.rst
+++ b/docs/modules/vertiq_40xx_family.rst
@@ -88,7 +88,7 @@ Required IQUART or Hobby Configuration
 
         Vertiq 40-XX Serial Connections
 
-In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <manual_hobby>` you will have to connect communication wiring to your module. 
+In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <hobby_protocol>` you will have to connect communication wiring to your module. 
 In any scenario, please ensure that the TX line of your module is connected to your controller's RX line, and the RX line 
 of your module is connected to your controller's TX line.
 

--- a/docs/modules/vertiq_81xx_family.rst
+++ b/docs/modules/vertiq_81xx_family.rst
@@ -81,7 +81,7 @@ Required IQUART or Hobby Configuration
 
         Vertiq 81-XX G1 Family Serial Connections
 
-In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <manual_hobby>` you will have to connect communication wiring to your module. 
+In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <hobby_protocol>` you will have to connect communication wiring to your module. 
 In any scenario, please ensure that the TX line of your module is connected to your controller's RX line, and the RX line 
 of your module is connected to your controller's TX line.
 
@@ -205,7 +205,7 @@ Required IQUART or Hobby Configuration
 
         Vertiq 81-XX G2 Serial Connections
 
-In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <manual_hobby>` you will have to connect communication wiring to your module. 
+In order to use either :ref:`IQUART <uart_messaging>` or any :ref:`Hobby Protocols <hobby_protocol>` you will have to connect communication wiring to your module. 
 In any scenario, please ensure that the TX line of your module is connected to your controller's RX line, and the RX line 
 of your module is connected to your controller's TX line.
 


### PR DESCRIPTION
Some links got broken in the transition to having separate comms protocol manuals. This fixes all of those references.