### PR TITLE
Bugfix/fix broken links and Update 81 G1 KV

### DIFF
--- a/docs/modules/vertiq_40xx_family.rst
+++ b/docs/modules/vertiq_40xx_family.rst
@@ -193,7 +193,7 @@ Additional Mechanical/Electrical Information
 For more information about the Vertiq 40-XX family's mechanical and electrical characteristics please visit the correct datasheet for your module using the links below
 
 * `40-06 370Kv G2 Datasheet <https://www.vertiq.co/s/VERT-M341-E200-Vertiq_40-06_370Kv_datasheet.pdf>`_
-* `40-06 770Kv G2 Datasheet <https://www.vertiq.co/s/VERT-M411-E200-Vertiq_40-06_770Kv_datasheet-bjff.pdf>`_
+* `40-06 770Kv G2 Datasheet <https://www.vertiq.co/s/VERT-M411-E200-Vertiq_40-06_770Kv_datasheet.pdf>`_
 * `40-14 400Kv G2 Datasheet <https://www.vertiq.co/s/VERT-M351-E200-Vertiq_40-14_400Kv_datasheet.pdf>`_
 
 

--- a/docs/modules/vertiq_81xx_family.rst
+++ b/docs/modules/vertiq_81xx_family.rst
@@ -16,7 +16,7 @@ Vertiq 81-XX Family
 
         "81-08", "85", "Speed", "Speed, Servo"
         "81-08", "150", "Speed", "Speed, Servo"
-        "81-08", "220", "Speed", "Speed, Servo"
+        "81-08", "240", "Speed", "Speed, Servo"
 
 .. csv-table:: Vertiq 81-XX Generation 2 Family of Modules
         :header: "Size", "Kv", "Default Firmware", "Available Firmware"
@@ -299,9 +299,9 @@ Additional Mechanical/Electrical Information
 ***************************************************
 For more information about the Vertiq 81-XX family's mechanical and electrical characteristics please visit the correct datasheet for your module using the links below
 
-* `81-08 G1 85Kv Datasheet <https://www.vertiq.co/s/Vertiq_81-08_85Kv_module_datasheet-mcn8.pdf>`_
-* `81-08 G1 150Kv Datasheet <https://www.vertiq.co/s/Vertiq_81-08_150Kv_module_datasheet-k4f2.pdf>`_
-* `81-08 G1 220Kv Datasheet <https://www.vertiq.co/s/Vertiq_81_08_220Kv_module_preliminary_datasheet-3say.pdf>`_
+* `81-08 G1 85Kv Datasheet <https://www.vertiq.co/s/VERT-M280-E160-Vertiq_81-08_85Kv_datasheet.pdf>`_
+* `81-08 G1 150Kv Datasheet <https://www.vertiq.co/s/VERT-M160-E160-Vertiq_81-08_150Kv_datasheet.pdf>`_
+* `81-08 G1 240Kv Datasheet <https://www.vertiq.co/s/VERT-M390-E160-Vertiq_81-08_240Kv_datasheet.pdf>`_
 
 * `81-08 G2 85Kv Datasheet <https://www.vertiq.co/s/VERT-M281-E161-Vertiq_81-08_85Kv_datasheet.pdf>`_
 * `81-08 G2 140Kv Datasheet <https://www.vertiq.co/s/VERT-M161-E161-Vertiq_81-08_140Kv_datasheet.pdf>`_


### PR DESCRIPTION
What the title says. We've decided that the 81-08 G1 220Kv is actually a 240. So, I've updated RTD with that. Also fixed one of the 40 datasheet links.