### PR TITLE
Fix Python and C++ Examples

### DIFF
--- a/docs/client_reference/client_reference_table.rst
+++ b/docs/client_reference/client_reference_table.rst
@@ -1,4 +1,6 @@
 .. include:: ../text_colors.rst
+.. include:: common_client_variables.rst
+
 .. toctree::
 
 .. _iquart_client_reference_tables:

--- a/docs/client_reference/common_client_variables.rst
+++ b/docs/client_reference/common_client_variables.rst
@@ -1,0 +1,4 @@
+
+.. |module_name| replace:: Vertiq8108
+.. |module_name_comment| replace:: # Please note that you should replace Vertiq8108 with the object type matching your module family.
+.. |variable_name| replace:: module

--- a/docs/client_reference/common_client_variables.rst
+++ b/docs/client_reference/common_client_variables.rst
@@ -1,4 +1,3 @@
-
 .. |module_name| replace:: Vertiq8108
 .. |module_name_comment| replace:: # Please note that you should replace Vertiq8108 with the object type matching your module family.
 .. |variable_name| replace:: module

--- a/docs/clients/adc_interface.rst
+++ b/docs/clients/adc_interface.rst
@@ -54,11 +54,11 @@ A minimal working example for the AdcInterfaceClient is:
         // Make a communication interface object
         GenericInterface com;
 
-        // Make a ADC Interface object with obj_id 0
+        // Make an ADC Interface object with obj_id 0
         AdcInterfaceClient adcInterface(0);
 
         // Use the ADC Interface Client
-        adcInterface.adc_voltage_.get(com)
+        adcInterface.adc_voltage_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -96,7 +96,7 @@ A minimal working example for the ADC Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo") |module_name_comment|
     
     adc_voltage = |variable_name|.get("adc_interface", "adc_voltage") 
     print(f"adc voltage : {adc_voltage}")

--- a/docs/clients/anticogging.rst
+++ b/docs/clients/anticogging.rst
@@ -56,10 +56,10 @@ A minimal working example for the AnticoggingClient is:
         // Make a communication interface object
         GenericInterface com;
         
-        // Make a ESC Propeller Input Parser object with obj_id 0
+        // Make an Anticogging Client object with obj_id 0
         AnticoggingClient cog(0);
         
-        // Use the ESC Propeller Input Parser object
+        // Use theAnticogging Client object
         cog.is_enabled_.set(com, 1);
         
         // Insert code for interfacing with hardware here
@@ -101,7 +101,7 @@ A minimal working example for the Anticogging Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo") |module_name_comment|
     
     |variable_name|.set("anticogging", "is_enabled", 1)  # Turns on Anticogging
 

--- a/docs/clients/anticogging.rst
+++ b/docs/clients/anticogging.rst
@@ -59,7 +59,7 @@ A minimal working example for the AnticoggingClient is:
         // Make an Anticogging Client object with obj_id 0
         AnticoggingClient cog(0);
         
-        // Use theAnticogging Client object
+        // Use the Anticogging Client object
         cog.is_enabled_.set(com, 1);
         
         // Insert code for interfacing with hardware here

--- a/docs/clients/arming_handler.rst
+++ b/docs/clients/arming_handler.rst
@@ -61,7 +61,7 @@ A minimal working example for the ArmingHandlerClient is:
         ArmingHandlerClient armingHandler(0);
 
         // Use the Arming Handler Client
-        armingHandler.always_armed_.get(com)
+        armingHandler.always_armed_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -99,7 +99,7 @@ A minimal working example for the Arming Handler Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     always_armed_status = |variable_name|.get("arming_handler", "always_armed") 
     print(f"Always armed status: {always_armed_status}")

--- a/docs/clients/brushless_drive.rst
+++ b/docs/clients/brushless_drive.rst
@@ -50,7 +50,7 @@ A minimal working example for the BrushlessDriveClient is:
     // This is what creates and parses packets
     GenericInterface com;
 
-    // Make a Temperature Estimator Client object with obj_id 0
+    // Make a Brushless Drive Client object with obj_id 0
     BrushlessDriveClient brushless(0);
 
     // Drives the motor at 3 Volts
@@ -96,7 +96,7 @@ A minimal working example for the BrushlessDriveClient is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("brushless_drive", "drive_spin_volts", 5) # Spins motor at 5 volts
 

--- a/docs/clients/buzzer_control.rst
+++ b/docs/clients/buzzer_control.rst
@@ -107,7 +107,7 @@ A minimal working example for the Buzzer Control Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("buzzer_control", "hz", 440)         # A4
     |variable_name|.set("buzzer_control", "volume", 127)     # Max Volume

--- a/docs/clients/coil_temperature_estimator.rst
+++ b/docs/clients/coil_temperature_estimator.rst
@@ -62,7 +62,7 @@ A minimal working example for the TemperatureEstimatorClient is:
         CoilTemperatureEstimatorClient temp_client(0);
 
         // Use the Temperature Estimator Client
-        temp_client.temp_.get(com)
+        temp_client.temp_.get(com);
 
         // [Insert code for interfacing with hardware here]
 
@@ -102,7 +102,7 @@ A minimal working example for the Temperature Estimator Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     coil_temp = |variable_name|.get("coil_temperature_estimator", "t_coil")  # Estimated Motor Temperature
     print(f"Estimated Motor Temperature: {coil_temp}")

--- a/docs/clients/coil_temperature_estimator_full.rst
+++ b/docs/clients/coil_temperature_estimator_full.rst
@@ -62,7 +62,7 @@ A minimal working example for the TemperatureEstimatorClient is:
         CoilTemperatureEstimatorClient temp_client(0);
 
         // Use the Temperature Estimator Client
-        temp_client.temp_.get(com)
+        temp_client.temp_.get(com);
 
         // [Insert code for interfacing with hardware here]
 
@@ -102,7 +102,7 @@ A minimal working example for the Temperature Estimator Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     coil_temp = |variable_name|.get("coil_temperature_estimator", "t_coil")  # Estimated Motor Temperature
     print(f"Estimated Motor Temperature: {coil_temp}")

--- a/docs/clients/esc_propeller_input_parser.rst
+++ b/docs/clients/esc_propeller_input_parser.rst
@@ -1,4 +1,3 @@
-
 .. _esc_propeller_input_parser:
 
 ESC Propeller Input Parser
@@ -104,7 +103,7 @@ A minimal working example for the ESC Propeller Input Parser Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("esc_propeller_input_parser", "velocity_max", 1000) # Set max Velocity to 1000rad/s
 

--- a/docs/clients/gpio_controller.rst
+++ b/docs/clients/gpio_controller.rst
@@ -64,7 +64,7 @@ A minimal working example for the GpioControllerClient is:
         GpioControllerClient gpioController(0);
 
         // Use the GPIO Controller Client
-        gpioController.mode_register_.get(com)
+        gpioController.mode_register_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -102,8 +102,7 @@ A minimal working example for the GPIO Controller Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")
-    
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo") |module_name_comment|   
     mode_register = |variable_name|.get("gpio_controller", "mode_register") 
     print(f"mode register: {mode_register}")
 

--- a/docs/clients/hobby_input.rst
+++ b/docs/clients/hobby_input.rst
@@ -98,7 +98,7 @@ A minimal working example for the Hobby Input Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("hobby_input", "allowed_protocols", 4)   # Set the protocol to MultiShot
     |variable_name|.save("hobby_input", "allowed_protocols")     # Save the protocol 

--- a/docs/clients/iquart_flight_controller_interface.rst
+++ b/docs/clients/iquart_flight_controller_interface.rst
@@ -59,12 +59,12 @@ A minimal working example for the IQUartFlightControllerInterfaceClient using th
         IQUartFlightControllerInterfaceClient iquartFlightControllerInterface(0);
 
         // Use the IQUART Flight Controller Interface Client
-        iquartFlightControllerInterface.telemetry_.get(com)
+        iquartFlightControllerInterface.telemetry_.get(com);
 
         // Insert code for interfacing with hardware here  
 
         // Store telemetry data in an IFCITelemetryData object
-        IFCITelemetryData telemetry = iquart_flight_controller_interface.telemetry_.get_reply()
+        IFCITelemetryData telemetry = iquart_flight_controller_interface.telemetry_.get_reply();
 
         // Examples on how to access each property of IFCITelemetryData
         cout << "telemetry coil_temp: " << telemetry.coil_temp << endl;
@@ -110,7 +110,7 @@ A minimal working example for the IQUART Flight Controller Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing") |module_name_comment|
     
     telemetry = |variable_name|.get("iquart_flight_controller_interface", "telemetry") 
     print(f"Pulsing voltage mode: {telemetry}")

--- a/docs/clients/multi_turn_angle_control.rst
+++ b/docs/clients/multi_turn_angle_control.rst
@@ -107,7 +107,7 @@ A minimal working example for the Multi-Turn Angle Control Client is:
     import math
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")  # Servo Firmware uses this client
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo")  # Servo Firmware uses this client  |module_name_comment|
     
     # Set the trajectory for the motor to complete 1 full rotation
     |variable_name|.set("multi_turn_angle_control", "trajectory_angular_displacement", 2*math.pi)

--- a/docs/clients/persistent_memory.rst
+++ b/docs/clients/persistent_memory.rst
@@ -100,7 +100,7 @@ A minimal working example for the Persistent Memory Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("persistent_memory", "format_key_1", 12345678)  # Set first key before erasing calibration data
     |variable_name|.set("persistent_memory", "format_key_2", 11223344)  # Set second key before erasing calibration data

--- a/docs/clients/power_monitor.rst
+++ b/docs/clients/power_monitor.rst
@@ -103,7 +103,7 @@ A minimal working example for the Power Monitor Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     volts = |variable_name|.get("power_monitor", "volts")  # returns the input voltage to module
     print(f"Voltage coming into module: {volts}")

--- a/docs/clients/power_safety.rst
+++ b/docs/clients/power_safety.rst
@@ -1,4 +1,3 @@
-
 Power Safety
 -------------
 
@@ -102,7 +101,7 @@ A minimal working example for the Power Safety Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     fault_now = |variable_name|.get("power_safety", "fault_now")  
     print(f"current fault: {fault_now}")

--- a/docs/clients/propeller_motor_control.rst
+++ b/docs/clients/propeller_motor_control.rst
@@ -1,4 +1,3 @@
-
 .. _propeller_motor_control:
 
 Propeller Motor Control
@@ -109,7 +108,7 @@ A minimal working example for the Propeller Motor Control Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("propeller_motor_control", "ctrl_velocity", 5)  # Supplies 5V to motor
 

--- a/docs/clients/pulsing_rectangular_input_parser.rst
+++ b/docs/clients/pulsing_rectangular_input_parser.rst
@@ -55,7 +55,7 @@ A minimal working example for the PulsingRectangularInputParserClient is:
         PulsingRectangularInputParserClient pulsingRectangularInputParser(0);
 
         // Use the Pulsing Rectangular Input Parser Client
-        pulsingRectangularInputParser.pulsing_voltage_mode_.get(com)
+        pulsingRectangularInputParser.pulsing_voltage_mode_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -95,7 +95,7 @@ A minimal working example for the Pulsing Rectangular Input Parser Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing") |module_name_comment|
     
     pulsing_voltage_mode = |variable_name|.get("pulsing_rectangular_input_parser", "pulsing_voltage_mode") 
     print(f"Pulsing voltage mode: {pulsing_voltage_mode}")

--- a/docs/clients/pwm_interface.rst
+++ b/docs/clients/pwm_interface.rst
@@ -61,7 +61,7 @@ A minimal working example for the PwmInterfaceClient is:
         PwmInterfaceClient pwmInterface(0);
 
         // Use the PWM Interface Client
-        pwmInterface.pwm_frequency_.get(com)
+        pwmInterface.pwm_frequency_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -101,7 +101,7 @@ A minimal working example for the PWM Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo") |module_name_comment|
     
     pwm_frequency = |variable_name|.get("pwm_interface", "pwm_frequency") 
     print(f"pwm frequency: {pwm_frequency}")

--- a/docs/clients/rgb_led.rst
+++ b/docs/clients/rgb_led.rst
@@ -98,7 +98,7 @@ A minimal working example for the RGB LED Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="speed")
+    |variable_name| = iq.|module_name|(com, 0, firmware="speed") |module_name_comment|
     
     red = |variable_name|.get("rgb_led", "red") 
     print(f"Red Intensity: {red}")

--- a/docs/clients/serial_interface.rst
+++ b/docs/clients/serial_interface.rst
@@ -124,7 +124,7 @@ A minimal working example for the Serial Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     |variable_name|.set("serial_interface", "baud_rate", 9600)  # change baud rate to 9600
 

--- a/docs/clients/servo_input_parser.rst
+++ b/docs/clients/servo_input_parser.rst
@@ -1,4 +1,3 @@
-
 .. _servo_input_parser:
 
 Servo Input Parser
@@ -109,7 +108,7 @@ A minimal working example for the Servo Input Parser Client is:
     import math
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="servo")
+    |variable_name| = iq.|module_name|(com, 0, firmware="servo") |module_name_comment|
     
     # Set Servo Limits
     |variable_name|.set("servo_input_parser", "mode", 3)             # Position Control Mode 

--- a/docs/clients/step_direction_input.rst
+++ b/docs/clients/step_direction_input.rst
@@ -105,9 +105,9 @@ A minimal working example for the Step Direction Input Client is:
     import math
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
-    |variable_name|.set("step_direction_input", "angle_step", (2*math.pi)/65536))  # Set min step angle
+    |variable_name|.set("step_direction_input", "angle_step", (2*math.pi)/65536)  # Set min step angle
     
 Message Table
 ~~~~~~~~~~~~~

--- a/docs/clients/stopping_handler.rst
+++ b/docs/clients/stopping_handler.rst
@@ -57,7 +57,7 @@ A minimal working example for the StoppingHandlerClient is:
         StoppingHandlerClient temp_client(0);
 
         // Use the Temperature Estimator Client
-        temp_client.stopped_speed_.get(com)
+        temp_client.stopped_speed_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -97,7 +97,7 @@ A minimal working example for the Stopping Handler Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     stopped_speed = |variable_name|.get("stopping_handler", "stopped_speed") 
     print(f"Stopped speed: {stopped_speed}")

--- a/docs/clients/stow_user_interface.rst
+++ b/docs/clients/stow_user_interface.rst
@@ -1,4 +1,3 @@
-
 Stow User Interface
 -------------------
 The :ref:`Stow Position <manual_stow_position>` feature allows a Vertiq module to return to a configurable position on a transition from armed to disarmed,
@@ -61,7 +60,7 @@ A minimal working example for the StowUserInterfaceClient is:
         StowUserInterfaceClient stowUserInterface(0);
 
         // Use the Temperature Estimator Client
-        stowUserInterface.zero_angle_.get(com)
+        stowUserInterface.zero_angle_.get(com);
 
         // [Insert code for interfacing with hardware here]
     }
@@ -101,7 +100,7 @@ A minimal working example for the Stow User Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     zero_angle = |variable_name|.get("stow_user_interface", "zero_angle") 
     print(f"Zero angle: {zero_angle}")

--- a/docs/clients/system_control.rst
+++ b/docs/clients/system_control.rst
@@ -103,7 +103,7 @@ A minimal working example for the System Control Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     FW = |variable_name|.get("system_control", "firmware_version")  # Firmware Version Number
     print(f"Firmware: {FW}")

--- a/docs/clients/temperature_estimator.rst
+++ b/docs/clients/temperature_estimator.rst
@@ -60,7 +60,7 @@ A minimal working example for the TemperatureEstimatorClient is:
         TemperatureEstimatorClient temp_client(0);
 
         // Use the Temperature Estimator Client
-        temp_client.temp_.get(com)
+        temp_client.temp_.get(com);
 
         // [Insert code for interfacing with hardware here]
     }
@@ -100,7 +100,7 @@ A minimal working example for the Temperature Estimator Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     temp = |variable_name|.get("temperature_estimator", "temp")  # Estimated Motor Temperature
     print(f"Estimated Motor Temperature: {temp}")

--- a/docs/clients/temperature_monitor_uc.rst
+++ b/docs/clients/temperature_monitor_uc.rst
@@ -105,7 +105,7 @@ A minimal working example for the Temperature Monitor Microcontroller Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     temp = |variable_name|.get("temperature_monitor_uc", "uc_temp")  # Internal UC Temperature
     print(f"Internal UC temperature: {temp}")

--- a/docs/clients/uavcan_node.rst
+++ b/docs/clients/uavcan_node.rst
@@ -55,7 +55,7 @@ A minimal working example for the UavcanNodeClient is:
         UavcanNodeClient uavcanNode(0);
 
         // Use the UAVCAN Node Client
-        uavcanNode.uavcan_node_id_.get(com)
+        uavcanNode.uavcan_node_id_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -95,7 +95,7 @@ A minimal working example for the UAVCAN Node Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0)
+    |variable_name| = iq.|module_name|(com, 0) |module_name_comment|
     
     uavcan_node_id = |variable_name|.get("uavcan_node", "uavcan_node_id") 
     print(f"UAVCAN Node ID: {uavcan_node_id}")

--- a/docs/clients/voltage_superposition.rst
+++ b/docs/clients/voltage_superposition.rst
@@ -55,7 +55,7 @@ A minimal working example for the VoltageSuperpositionClient is:
         VoltageSuperpositionClient voltageSuperposition(0);
 
         // Use the Voltage Superposition Client
-        voltageSuperposition.zero_angle_.get(com)
+        voltageSuperposition.zero_angle_.get(com);
 
         // Insert code for interfacing with hardware here  
     }
@@ -95,7 +95,7 @@ A minimal working example for the Voltage Superposition Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing")
+    |variable_name| = iq.|module_name|(com, 0, firmware="pulsing") |module_name_comment|
     
     zero_angle= |variable_name|.get("voltage_superposition", "zero_angle") 
     print(f"Zero angle: {zero_angle}")

--- a/docs/clients/white_led.rst
+++ b/docs/clients/white_led.rst
@@ -98,7 +98,7 @@ A minimal working example for the white LED Interface Client is:
     import iqmotion as iq
 
     com = iq.SerialCommunicator("/dev/ttyUSB0")
-    |variable_name| = iq.|module_name|(com, 0, firmware="speed")
+    |variable_name| = iq.|module_name|(com, 0, firmware="speed") |module_name_comment|
     
     intensity = |variable_name|.get("white_led", "intensity") 
     print(f"Intensity: {intensity}")

--- a/docs/tutorials/ifci_px4_flight_controller.rst
+++ b/docs/tutorials/ifci_px4_flight_controller.rst
@@ -29,7 +29,7 @@ This should result in tags being added to the local repository. Once this is don
 .. once we are in px4, this whole section can be replaced with install px4 toolchain as described by them
 
 Setting Up PX4 for IQUART and Building
-======================================
+=========================================
 
 Once the toolchain is set up, you must change the settings for your board to turn on Vertiq IQUART integrations. To do this, enter your PX4 directory and use the command below, but replace ``<your-flight-control-board>`` with your flight control board's name.
 
@@ -179,7 +179,7 @@ After reboot, and with Vertiq IO enabled, you should now see a :blue:`Vertiq IO`
 Now your Vertiq modules must be configured for proper communication with the flight controller.
 
 Configuring Your Vertiq Modules for Use with IFCI and PX4
-========================================================
+=============================================================
 To use your Vertiq modules properly with IFCI, your modules must be flashed with a compatible firmware version. Please consult your module's family page to find if your module supports IFCI. Once flashed with appropriate firmware, connect each module **individually** to IQ Control Center and set the :blue:`UART Baud Rate` and the :red:`Module ID`. As stated previously, we recommend that you use a baud rate of 921600. Both of these parameters will cause the motor to disconnect when set, so make sure you reconnect to the motor after each one is set. When the baud rate is changed you will have to adjust the baud rate in the IQ Control Center to be able to reconnect to the motor. For this reason we recommend changing the module ID and then changing the baud rate. This avoids needing to change the baud rate of IQ Control Center at all. Ensure that each module connected to the flight controller is set to a unique module ID. For this tutorial, we will be using the module IDs 0, 1, 2, and 3. Once all of the modules have different IDs and matching baud rates they can all be connected to IQ Control Center using a single USB port with the wiring diagram shown in the :ref:`Multiple Module Wiring guide<multiple_module_wiring>` if desired.
 
 .. figure:: ../_static/tutorial_images/ifci_px4_flight_controller/control_center_settings_module_id.png


### PR DESCRIPTION
We were missing semicolons in some C++ examples, and the python examples had unfilled macros. This fixes those issues. There are also some small grammatical/formatting fixes that I hit while I was going through this. I also noticed that some of the links in the PX4/IFCI docs don't work, so I've made a backlog task to fix those as well.

Built docs are here: https://iqmotion.readthedocs.io/en/bugfix-update_api_examples/